### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,7 +10,7 @@ jobs:
     name: Secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: google/secrets-sync-action@v1.1.3
+      - uses: jpoehnelt/secrets-sync-action@v1.1.3
         with:
           SECRETS: |
             ^SYNCED_


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.